### PR TITLE
feat: Add tetromino skin change feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,16 @@
                 <input type="file" id="backgroundImageInput" accept="image/*">
                 <img id="backgroundPreview" src="" alt="Background Preview" style="max-width: 100px; max-height: 100px; display: none;">
             </div>
+            <div id="tetromino-skin-settings">
+                <h3>Tetromino Skin</h3>
+                <select id="tetrominoSkinSelect">
+                    <option value="default">Default</option>
+                    <option value="grayscale">Grayscale</option>
+                    <option value="red">Red</option>
+                    <option value="blue">Blue</option>
+                    <option value="green">Green</option>
+                </select>
+            </div>
         </div>
     </div>
     <script src="bundle.js"></script>

--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -16,6 +16,15 @@ export class Game {
   private tetrominoTypes = ['I', 'J', 'L', 'O', 'S', 'T', 'Z'];
   private onLineClearCallback: ((lines: number) => void) | null = null;
   private onLevelUpCallback: ((level: number) => void) | null = null;
+  private currentSkin: { [key: string]: string } = {
+    'I': 'cyan',
+    'J': 'blue',
+    'L': 'orange',
+    'O': 'yellow',
+    'S': 'lime',
+    'T': 'purple',
+    'Z': 'red',
+  }; // Default skin
 
   constructor(
     boardWidth: number,
@@ -29,6 +38,56 @@ export class Game {
     }
     if (onLevelUp) {
       this.onLevelUpCallback = onLevelUp;
+    }
+  }
+
+  public setTetrominoSkin(skinName: string): void {
+    // In a real scenario, you would load skin data from a predefined set
+    // For now, we'll use a simple mapping or assume skinName is a color
+    switch (skinName) {
+      case 'default':
+        this.currentSkin = {
+          'I': 'cyan',
+          'J': 'blue',
+          'L': 'orange',
+          'O': 'yellow',
+          'S': 'lime',
+          'T': 'purple',
+          'Z': 'red',
+        };
+        break;
+      case 'grayscale':
+        this.currentSkin = {
+          'I': '#808080',
+          'J': '#808080',
+          'L': '#808080',
+          'O': '#808080',
+          'S': '#808080',
+          'T': '#808080',
+          'Z': '#808080',
+        };
+        break;
+      // Add more cases for different skins
+      default:
+        // Assume skinName is a single color to apply to all
+        this.currentSkin = {
+          'I': skinName,
+          'J': skinName,
+          'L': skinName,
+          'O': skinName,
+          'S': skinName,
+          'T': skinName,
+          'Z': skinName,
+        };
+        break;
+    }
+    // Re-apply skin to current and next tetrominos if they exist
+    if (this.currentTetromino) {
+      this.currentTetromino = new Tetromino(this.currentTetromino.x, this.currentTetromino.y, this.currentTetromino.getType(), this.currentSkin);
+    }
+    this.nextTetrominos = this.nextTetrominos.map(t => new Tetromino(t.x, t.y, t.getType(), this.currentSkin));
+    if (this.holdTetromino) {
+      this.holdTetromino = new Tetromino(this.holdTetromino.x, this.holdTetromino.y, this.holdTetromino.getType(), this.currentSkin);
     }
   }
 
@@ -114,7 +173,7 @@ export class Game {
 
   private generateRandomTetromino(): Tetromino {
     const randomType = this.tetrominoTypes[Math.floor(Math.random() * this.tetrominoTypes.length)];
-    return new Tetromino(Math.floor(this.board.width / 2) - 2, 0, randomType);
+    return new Tetromino(Math.floor(this.board.width / 2) - 2, 0, randomType, this.currentSkin);
   }
 
   handleInput(key: string): void {

--- a/src/core/Tetromino.ts
+++ b/src/core/Tetromino.ts
@@ -3,14 +3,14 @@ export class Tetromino {
   public y: number;
   private shape: number[][];
   private type: string;
-  private color: string;
+  private skin: { [key: string]: string }; // Add skin property
 
-  constructor(x: number, y: number, type: string) {
+  constructor(x: number, y: number, type: string, skin: { [key: string]: string }) {
     this.x = x;
     this.y = y;
     this.type = type;
     this.shape = this.getInitialShape(type);
-    this.color = this.getColorForType(type);
+    this.skin = skin; // Assign skin
   }
 
   private getInitialShape(type: string): number[][] {
@@ -34,21 +34,8 @@ export class Tetromino {
     }
   }
 
-  private getColorForType(type: string): string {
-    switch (type) {
-      case 'I': return 'cyan';
-      case 'J': return 'blue';
-      case 'L': return 'orange';
-      case 'O': return 'yellow';
-      case 'S': return 'lime';
-      case 'T': return 'purple';
-      case 'Z': return 'red';
-      default: return 'gray';
-    }
-  }
-
-  getColor(): string {
-    return this.color;
+  getSkinColor(): string {
+    return this.skin[this.type] || 'gray'; // Return color based on skin
   }
 
   move(dx: number, dy: number): void {

--- a/src/graphics/Renderer.ts
+++ b/src/graphics/Renderer.ts
@@ -85,7 +85,7 @@ export class Renderer {
 
   drawTetromino(tetromino: Tetromino): void {
     const shape = tetromino.getShape();
-    const color = tetromino.getColor();
+    const color = tetromino.getSkinColor(); // Use getSkinColor()
 
     this.gameCtx.fillStyle = color;
     for (let y = 0; y < shape.length; y++) {
@@ -129,7 +129,7 @@ export class Renderer {
     let currentOffsetY = 0; // Start from top of nextCanvas
     for (const tetromino of tetrominos) {
       const shape = tetromino.getShape();
-      const color = tetromino.getColor();
+      const color = tetromino.getSkinColor(); // Use getSkinColor()
 
       this.nextCtx.fillStyle = color;
       for (let y = 0; y < shape.length; y++) {
@@ -151,7 +151,7 @@ export class Renderer {
   drawHoldTetromino(tetromino: Tetromino): void {
     this.clearHoldCanvas(); // Clear before drawing
     const shape = tetromino.getShape();
-    const color = tetromino.getColor();
+    const color = tetromino.getSkinColor(); // Use getSkinColor()
 
     this.holdCtx.fillStyle = color;
     for (let y = 0; y < shape.length; y++) {

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -9,6 +9,7 @@ export class UIManager {
     private gameOverElement: HTMLElement;
     private backgroundImageInput: HTMLInputElement;
     private backgroundPreview: HTMLImageElement;
+    private tetrominoSkinSelect: HTMLSelectElement; // Add new property
     private renderer: Renderer; // Add renderer property
 
     constructor(game: Game, renderer: Renderer) {
@@ -19,6 +20,7 @@ export class UIManager {
         this.gameOverElement = document.getElementById("gameOver")!;
         this.backgroundImageInput = document.getElementById("backgroundImageInput") as HTMLInputElement;
         this.backgroundPreview = document.getElementById("backgroundPreview") as HTMLImageElement;
+        this.tetrominoSkinSelect = document.getElementById("tetrominoSkinSelect") as HTMLSelectElement; // Get new element
         this.renderer = renderer; // Assign renderer
 
         this.startButton.addEventListener("click", () => {
@@ -43,6 +45,11 @@ export class UIManager {
                 this.backgroundPreview.style.display = "none";
                 this.renderer.setBackgroundImage(null); // Clear background image
             }
+        });
+
+        this.tetrominoSkinSelect.addEventListener("change", (event) => {
+            const selectedSkin = (event.target as HTMLSelectElement).value;
+            game.setTetrominoSkin(selectedSkin); // Call a new method in Game.ts
         });
     }
 


### PR DESCRIPTION
feat: Add tetromino skin change feature

This commit introduces the ability for users to change the skin of tetrominos.

- public/index.html:
  - Added a dropdown for tetromino skin selection.
- src/core/Game.ts:
  - Added `currentSkin` property to manage the active skin.
  - Added `setTetrominoSkin` method to update the skin and re-apply it to existing tetrominos.
  - Updated `generateRandomTetromino` to use the `currentSkin`.
- src/core/Tetromino.ts:
  - Replaced `color` property with `skin` property.
  - Replaced `getColorForType` with `getSkinColor` to retrieve color based on the active skin.
  - Updated constructor to accept skin.
- src/graphics/Renderer.ts:
  - Updated `drawTetromino`, `drawNextTetrominos`, and `drawHoldTetromino` to use `getSkinColor`.
- src/ui/UIManager.ts:
  - Added logic to handle tetromino skin selection and call `game.setTetrominoSkin`.